### PR TITLE
Replace nvcaffe_parser with nvparsers in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(OpenCV REQUIRED)
 file(GLOB_RECURSE sources modules/*.hpp modules/*.cpp modules/*.h modules/*.cu extra/*.h)
 add_library(detector SHARED ${sources})
 target_include_directories(detector PRIVATE extra/ modules/ ${OpenCV_INCLUDE_DIRS} ${CUDA_TOOLKIT_ROOT_DIR}/include)
-target_link_libraries(detector nvinfer nvinfer_plugin nvcaffe_parser "stdc++fs")
+target_link_libraries(detector nvinfer nvinfer_plugin nvparsers "stdc++fs")
 
 #sample
 add_executable(yolo-trt samples/sample_detector.cpp)				  


### PR DESCRIPTION
Replace nvcaffe_parser with nvparsers in CMakeLists.txt
[Build error when using make in official nvidia docker](https://github.com/dusty-nv/jetson-inference/issues/610#issuecomment-642653592)
#97 