### PR TITLE
Better compatibility with Linux

### DIFF
--- a/modules/yolo.cpp
+++ b/modules/yolo.cpp
@@ -1016,7 +1016,7 @@ std::vector<std::map<std::string, std::string>> Yolo::parseConfigFile(const std:
 
     while (getline(file, line))
     {
-        if (line.empty()) continue;
+        if (line.empty() || line == "\r") continue;
         if (line.front() == '#') continue;
         line = trim(line);
         if (line.front() == '[')


### PR DESCRIPTION
When I use it on centos7, it reports an error like this:`terminate called after throwing an instance of 'std::out_of_range'
	what(): map::at`，
I eventually found out that Linux does not treat the blank lines in the configuration file yolov5s6.cfg the same way Windows does. When reading a blank line, 'line.empty()=true' under Windows, and 'line="\r"' under Centos7, so 'line.empty()=false'.