### PR TITLE
fix yolov4 broken detection

### DIFF
--- a/modules/chunk.cu
+++ b/modules/chunk.cu
@@ -71,8 +71,8 @@ namespace nvinfer1
 		//batch
 		for (int b = 0; b < batchSize; ++b)
 		{
-			NV_CUDA_CHECK(cudaMemcpy((char*)outputs[0] + b * _n_size_split, (char*)inputs[0] + b * 2 * _n_size_split, _n_size_split, cudaMemcpyDeviceToDevice));
-			NV_CUDA_CHECK(cudaMemcpy((char*)outputs[1] + b * _n_size_split, (char*)inputs[0] + b * 2 * _n_size_split + _n_size_split, _n_size_split, cudaMemcpyDeviceToDevice));
+			NV_CUDA_CHECK(cudaMemcpyAsync((char*)outputs[0] + b * _n_size_split, (char*)inputs[0] + b * 2 * _n_size_split, _n_size_split, cudaMemcpyDeviceToDevice, stream));
+			NV_CUDA_CHECK(cudaMemcpyAsync((char*)outputs[1] + b * _n_size_split, (char*)inputs[0] + b * 2 * _n_size_split + _n_size_split, _n_size_split, cudaMemcpyDeviceToDevice, stream));
 		}
 	//	NV_CUDA_CHECK(cudaMemcpy(outputs[0], inputs[0], _n_size_split, cudaMemcpyDeviceToDevice));
 	//	NV_CUDA_CHECK(cudaMemcpy(outputs[1], (void*)((char*)inputs[0] + _n_size_split), _n_size_split, cudaMemcpyDeviceToDevice));

--- a/modules/hardswish.cu
+++ b/modules/hardswish.cu
@@ -69,7 +69,7 @@ namespace nvinfer1
 	{
 		int n_data_size = n_batch_size_ * n_output_size_;
 //		printf("cuda_hardswish_layer:%d,size:%d\n", n_batch_size_, n_output_size_);
-		kernel_hardswish << <(n_data_size + threads_ -1)/threads_, threads_ >> >(
+		kernel_hardswish << <(n_data_size + threads_ -1)/threads_, threads_, 0, stream_ >> >(
 				reinterpret_cast<const float*>(input_),
 				reinterpret_cast<float*>(output_),
 				n_data_size);
@@ -83,7 +83,7 @@ namespace nvinfer1
 		cudaStream_t stream) noexcept
 	{
 //		printf("batch_size:%d,output_size:%d,threads:%d\n", batchSize, _n_output_size, _n_max_thread_pre_block);
-		NV_CUDA_CHECK(cuda_hardswish_layer(inputs[0], outputs[0], batchSize, _n_output_size , _n_max_thread_pre_block,stream));
+		NV_CUDA_CHECK(cuda_hardswish_layer(inputs[0], outputs[0], batchSize, _n_output_size , _n_max_thread_pre_block, stream));
 		return 0;
 	}
 

--- a/modules/mish.cu
+++ b/modules/mish.cu
@@ -152,7 +152,7 @@ namespace nvinfer1
 	{
         int block_size = thread_count_;
         int grid_size = (input_size_ * batchSize + block_size - 1) / block_size;
-        mish_kernel<<<grid_size, block_size>>>(inputs[0], output, input_size_ * batchSize);
+        mish_kernel<<<grid_size, block_size, 0, stream>>>(inputs[0], output, input_size_ * batchSize);
     }
 
 	int MishPlugin::enqueue(int batchSize,

--- a/modules/yolo.cpp
+++ b/modules/yolo.cpp
@@ -1038,9 +1038,9 @@ std::vector<std::map<std::string, std::string>> Yolo::parseConfigFile(const std:
 
     while (getline(file, line))
     {
+        line = trim(line);
         if (line.empty()) continue;
         if (line.front() == '#') continue;
-        line = trim(line);
         if (line.front() == '[')
         {
             if (!block.empty())


### PR DESCRIPTION
1- fix missing cuda stream in calls to cuda kernels of mish, chunk and hardswish.
2- in parsing the config, trim the line before checking its empty, otherwise it could crash while checking an empty line for # symbol.